### PR TITLE
Fixed typo in windows build script

### DIFF
--- a/buildScripts/windows.bat
+++ b/buildScripts/windows.bat
@@ -1,1 +1,1 @@
-gradlew build -PbuiltType=windows -PtestType=windows
+gradlew build -PbuildType=windows -PtestType=windows


### PR DESCRIPTION
There was a typo that stopped vision from building on windows
